### PR TITLE
Add Python README documentation and performance tests

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -98,7 +98,7 @@ except SymbolParseError as e:
     print(f"Message: {e}")                      # [E004] ...
 
 try:
-    symbol = parse_symbol("XXXX:7203")  # 不明な取引所
+    symbol = parse_symbol("XX:7203")  # 無効な取引所形式 (4文字でない)
 except SymbolParseError as e:
     print(f"Error code: {e.error_code.value}")  # E007
 ```
@@ -224,7 +224,7 @@ assert symbol == restored
 | E004 | 無効なセグメント数 |
 | E005 | 無効な日付 |
 | E006 | 無効なオプション種別 |
-| E007 | 不明な取引所コード |
+| E007 | 無効な取引所コード形式 |
 | E008 | 無効な証券/商品コード |
 | E009 | 無効な権利行使価格 |
 | E010 | シンボル文字列が長すぎる |

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,261 @@
+# marketsymbol
+
+金融商品シンボルの統一表記と変換を提供する Python ライブラリ。
+
+## Features
+
+- シンボル文字列のパース・正規化・バリデーション
+- 株式、先物、オプションの各資産クラスをサポート
+- ベンダー固有フォーマットとの相互変換（アダプター機構）
+- 型安全な API（`mypy --strict` 対応）
+- Python 3.13+ 対応
+
+## Installation
+
+```bash
+pip install marketsymbol
+```
+
+## Quick Start
+
+### シンボルのパース
+
+```python
+from marketsymbol import parse_symbol
+
+# 株式シンボル
+stock = parse_symbol("XJPX:7203")
+print(stock.exchange)     # "XJPX"
+print(stock.code)         # "7203"
+print(stock.asset_class)  # AssetClass.EQUITY
+print(str(stock))         # "XJPX:7203"
+
+# 先物シンボル
+future = parse_symbol("XJPX:NK:20250314:F")
+print(future.exchange)    # "XJPX"
+print(future.code)        # "NK"
+print(future.expiry)      # "20250314"
+print(future.asset_class) # AssetClass.FUTURE
+
+# オプションシンボル
+option = parse_symbol("XJPX:N225O:20250314:C:42000")
+print(option.exchange)     # "XJPX"
+print(option.code)         # "N225O"
+print(option.expiry)       # "20250314"
+print(option.option_type)  # OptionType.CALL
+print(option.strike)       # 42000
+print(option.asset_class)  # AssetClass.OPTION
+```
+
+### シンボルの正規化
+
+```python
+from marketsymbol import normalize_symbol
+
+# 小文字を大文字に
+print(normalize_symbol("xjpx:7203"))      # "XJPX:7203"
+
+# 全角を半角に
+print(normalize_symbol("ＸＪＰＸ：７２０３"))  # "XJPX:7203"
+
+# 空白を除去
+print(normalize_symbol("  XJPX:7203  "))  # "XJPX:7203"
+```
+
+### シンボルの直接生成
+
+```python
+from marketsymbol import EquitySymbol, FutureSymbol, OptionSymbol, OptionType
+
+# 株式シンボル
+stock = EquitySymbol(exchange="XJPX", code="7203")
+print(str(stock))  # "XJPX:7203"
+
+# 先物シンボル
+future = FutureSymbol(exchange="XJPX", code="NK", expiry="20250314")
+print(str(future))  # "XJPX:NK:20250314:F"
+
+# オプションシンボル
+option = OptionSymbol(
+    exchange="XJPX",
+    code="N225O",
+    expiry="20250314",
+    option_type=OptionType.CALL,
+    strike=42000
+)
+print(str(option))  # "XJPX:N225O:20250314:C:42000"
+```
+
+### エラーハンドリング
+
+```python
+from marketsymbol import parse_symbol, SymbolParseError
+
+try:
+    symbol = parse_symbol("INVALID")
+except SymbolParseError as e:
+    print(f"Error code: {e.error_code.value}")  # E004
+    print(f"Message: {e}")                      # [E004] ...
+
+try:
+    symbol = parse_symbol("XXXX:7203")  # 不明な取引所
+except SymbolParseError as e:
+    print(f"Error code: {e.error_code.value}")  # E007
+```
+
+### パターンマッチング
+
+```python
+from marketsymbol import parse_symbol, EquitySymbol, FutureSymbol, OptionSymbol
+
+symbol = parse_symbol("XJPX:NK:20250314:F")
+
+match symbol:
+    case EquitySymbol(exchange, code):
+        print(f"Equity: {exchange}:{code}")
+    case FutureSymbol(exchange, code, expiry):
+        print(f"Future: {exchange}:{code} expiry={expiry}")
+    case OptionSymbol(exchange, code, expiry, option_type, strike):
+        print(f"Option: {exchange}:{code}")
+```
+
+### 型安全な API
+
+```python
+from typing import assert_never
+from marketsymbol import Symbol, parse_symbol, EquitySymbol, FutureSymbol, OptionSymbol
+
+def describe_symbol(symbol: Symbol) -> str:
+    """mypy が全ケースの網羅を検証する."""
+    match symbol:
+        case EquitySymbol(exchange, code):
+            return f"Equity: {exchange}:{code}"
+        case FutureSymbol(exchange, code, expiry):
+            return f"Future: {exchange}:{code}:{expiry}:F"
+        case OptionSymbol(exchange, code, expiry, option_type, strike):
+            return f"Option: {exchange}:{code}:{expiry}:{option_type.value}"
+        case _ as unreachable:
+            assert_never(unreachable)
+```
+
+## Vendor Adapters
+
+ベンダー固有のシンボルフォーマットと統一シンボル間の変換をサポートします。
+
+```python
+from marketsymbol import (
+    BaseAdapter,
+    AdapterRegistry,
+    Symbol,
+    EquitySymbol,
+    AssetClass,
+)
+
+class MyVendorAdapter(BaseAdapter):
+    """カスタムベンダーアダプター."""
+
+    @property
+    def supported_asset_classes(self) -> frozenset[AssetClass]:
+        return frozenset({AssetClass.EQUITY})
+
+    def to_symbol(self, vendor_symbol: str) -> Symbol:
+        # "7203.T" -> EquitySymbol
+        code, suffix = vendor_symbol.split(".")
+        if suffix == "T":
+            return EquitySymbol(exchange="XJPX", code=code)
+        raise ValueError(f"Unknown suffix: {suffix}")
+
+    def from_symbol(self, symbol: Symbol) -> str:
+        # EquitySymbol -> "7203.T"
+        if isinstance(symbol, EquitySymbol) and symbol.exchange == "XJPX":
+            return f"{symbol.code}.T"
+        raise ValueError("Unsupported symbol")
+
+# Registry への登録
+registry = AdapterRegistry()
+registry.register("myvendor", MyVendorAdapter())
+
+# 使用
+adapter = registry.get("myvendor")
+if adapter:
+    symbol = adapter.to_symbol("7203.T")
+    vendor_str = adapter.from_symbol(symbol)
+```
+
+## Symbol Features
+
+### ハッシュ可能
+
+シンボルは辞書のキーやセットの要素として使用できます。
+
+```python
+from marketsymbol import parse_symbol, Symbol
+
+prices: dict[Symbol, float] = {
+    parse_symbol("XJPX:7203"): 2500.0,
+    parse_symbol("XJPX:9984"): 8000.0,
+}
+
+symbols: set[Symbol] = {
+    parse_symbol("XJPX:7203"),
+    parse_symbol("XJPX:9984"),
+}
+```
+
+### pickle 対応
+
+```python
+import pickle
+from marketsymbol import parse_symbol
+
+symbol = parse_symbol("XJPX:7203")
+data = pickle.dumps(symbol)
+restored = pickle.loads(data)
+assert symbol == restored
+```
+
+## Error Codes
+
+| Code | Description |
+|------|-------------|
+| E001 | 先物に権利行使価格を指定 |
+| E002 | オプション (C/P) に権利行使価格なし |
+| E003 | 無効な限月形式 |
+| E004 | 無効なセグメント数 |
+| E005 | 無効な日付 |
+| E006 | 無効なオプション種別 |
+| E007 | 不明な取引所コード |
+| E008 | 無効な証券/商品コード |
+| E009 | 無効な権利行使価格 |
+| E010 | シンボル文字列が長すぎる |
+
+## API Reference
+
+### Functions
+
+- `parse_symbol(s: str) -> Symbol` - シンボル文字列をパース
+- `normalize_symbol(s: str) -> str` - シンボル文字列を正規化
+
+### Classes
+
+- `EquitySymbol` - 株式・ETF シンボル
+- `FutureSymbol` - 先物シンボル
+- `OptionSymbol` - オプションシンボル
+- `BaseAdapter` - アダプター基底クラス
+- `AdapterRegistry` - アダプターレジストリ
+
+### Enums
+
+- `AssetClass` - 資産クラス (EQUITY, FUTURE, OPTION)
+- `OptionType` - オプション種別 (CALL, PUT, SERIES)
+- `ErrorCode` - エラーコード (E001-E010)
+
+### Exceptions
+
+- `SymbolError` - シンボル例外の基底クラス
+- `SymbolParseError` - パースエラー
+- `SymbolValidationError` - バリデーションエラー
+
+## License
+
+MIT License

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,6 +42,9 @@ addopts = [
 filterwarnings = [
     "error",  # 警告をエラーとして扱い、早期に問題を検出
 ]
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 # mypy configuration (strict mode)
 [tool.mypy]

--- a/python/tests/test_performance.py
+++ b/python/tests/test_performance.py
@@ -7,12 +7,13 @@ import time
 
 import pytest
 
-from marketsymbol import parse_symbol
+from marketsymbol import normalize_symbol, parse_symbol
 
 # パフォーマンス要件: 1ms = 0.001秒
 MAX_PARSE_TIME_SECONDS = 0.001
 
 
+@pytest.mark.slow
 class TestParseSymbolPerformance:
     """parse_symbol のパフォーマンステスト."""
 
@@ -32,7 +33,7 @@ class TestParseSymbolPerformance:
         Args:
             symbol: テスト対象のシンボル文字列.
         """
-        # Warm up - JIT やキャッシュの影響を排除
+        # Warm up - キャッシュ、遅延インポート、正規表現コンパイルの影響を排除
         for _ in range(100):
             parse_symbol(symbol)
 
@@ -49,31 +50,33 @@ class TestParseSymbolPerformance:
             f"(expected < {MAX_PARSE_TIME_SECONDS * 1000}ms)"
         )
 
-    def test_normalize_symbol_performance(self) -> None:
-        """正規化を含む parse_symbol が 1ms 以内で完了する."""
-        from marketsymbol import normalize_symbol
+    @pytest.mark.parametrize(
+        "symbol",
+        [
+            pytest.param("xjpx:7203", id="lowercase"),
+            pytest.param("ＸＪＰＸ：７２０３", id="fullwidth"),  # noqa: RUF001
+            pytest.param("  XJPX:7203  ", id="whitespace"),
+        ],
+    )
+    def test_normalize_symbol_under_1ms(self, symbol: str) -> None:
+        """normalize_symbol が 1ms 以内で完了する.
 
-        # 正規化が必要な入力
-        symbols = [
-            "xjpx:7203",  # 小文字
-            "ＸＪＰＸ：７２０３",  # noqa: RUF001  # 全角文字テスト
-            "  XJPX:7203  ",  # 空白
-        ]
+        Args:
+            symbol: テスト対象のシンボル文字列.
+        """
+        # Warm up - キャッシュ、遅延インポート、正規表現コンパイルの影響を排除
+        for _ in range(100):
+            normalize_symbol(symbol)
 
-        for symbol in symbols:
-            # Warm up
-            for _ in range(100):
-                normalize_symbol(symbol)
+        # 測定: 1000 回実行して平均を取る
+        iterations = 1000
+        start = time.perf_counter()
+        for _ in range(iterations):
+            normalize_symbol(symbol)
+        elapsed = time.perf_counter() - start
+        average_time = elapsed / iterations
 
-            # 測定
-            iterations = 1000
-            start = time.perf_counter()
-            for _ in range(iterations):
-                normalize_symbol(symbol)
-            elapsed = time.perf_counter() - start
-            average_time = elapsed / iterations
-
-            assert average_time < MAX_PARSE_TIME_SECONDS, (
-                f"normalize_symbol('{symbol}') took {average_time * 1000:.3f}ms "
-                f"(expected < {MAX_PARSE_TIME_SECONDS * 1000}ms)"
-            )
+        assert average_time < MAX_PARSE_TIME_SECONDS, (
+            f"normalize_symbol('{symbol}') took {average_time * 1000:.3f}ms "
+            f"(expected < {MAX_PARSE_TIME_SECONDS * 1000}ms)"
+        )

--- a/python/tests/test_performance.py
+++ b/python/tests/test_performance.py
@@ -1,0 +1,79 @@
+"""パフォーマンステスト (SC-PY-007 対応).
+
+parse_symbol の処理時間が 1ms (0.001秒) 以内で完了することを検証する。
+"""
+
+import time
+
+import pytest
+
+from marketsymbol import parse_symbol
+
+# パフォーマンス要件: 1ms = 0.001秒
+MAX_PARSE_TIME_SECONDS = 0.001
+
+
+class TestParseSymbolPerformance:
+    """parse_symbol のパフォーマンステスト."""
+
+    @pytest.mark.parametrize(
+        "symbol",
+        [
+            "XJPX:7203",  # Equity
+            "XJPX:NK:20250314:F",  # Future
+            "XJPX:N225O:20250314:C:42000",  # Option
+            "XJPX:N225O:20250314:O",  # Option series
+        ],
+        ids=["equity", "future", "option", "series"],
+    )
+    def test_parse_symbol_under_1ms(self, symbol: str) -> None:
+        """parse_symbol が 1ms 以内で完了する.
+
+        Args:
+            symbol: テスト対象のシンボル文字列.
+        """
+        # Warm up - JIT やキャッシュの影響を排除
+        for _ in range(100):
+            parse_symbol(symbol)
+
+        # 測定: 1000 回実行して平均を取る
+        iterations = 1000
+        start = time.perf_counter()
+        for _ in range(iterations):
+            parse_symbol(symbol)
+        elapsed = time.perf_counter() - start
+        average_time = elapsed / iterations
+
+        assert average_time < MAX_PARSE_TIME_SECONDS, (
+            f"parse_symbol('{symbol}') took {average_time * 1000:.3f}ms "
+            f"(expected < {MAX_PARSE_TIME_SECONDS * 1000}ms)"
+        )
+
+    def test_normalize_symbol_performance(self) -> None:
+        """正規化を含む parse_symbol が 1ms 以内で完了する."""
+        from marketsymbol import normalize_symbol
+
+        # 正規化が必要な入力
+        symbols = [
+            "xjpx:7203",  # 小文字
+            "ＸＪＰＸ：７２０３",  # noqa: RUF001  # 全角文字テスト
+            "  XJPX:7203  ",  # 空白
+        ]
+
+        for symbol in symbols:
+            # Warm up
+            for _ in range(100):
+                normalize_symbol(symbol)
+
+            # 測定
+            iterations = 1000
+            start = time.perf_counter()
+            for _ in range(iterations):
+                normalize_symbol(symbol)
+            elapsed = time.perf_counter() - start
+            average_time = elapsed / iterations
+
+            assert average_time < MAX_PARSE_TIME_SECONDS, (
+                f"normalize_symbol('{symbol}') took {average_time * 1000:.3f}ms "
+                f"(expected < {MAX_PARSE_TIME_SECONDS * 1000}ms)"
+            )


### PR DESCRIPTION
## Summary
- Add comprehensive README documentation for the Python library covering all features
- Include usage examples for symbol parsing, normalization, and direct symbol creation
- Document vendor adapter mechanism and error codes
- Add performance test suite for baseline measurements

## Test plan
- [ ] Verify README examples are accurate against current implementation
- [ ] Review performance tests execute correctly with `uv --directory ./python run pytest python/tests/test_performance.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)